### PR TITLE
修复两个Cloudcore连接到同一个k8s时的configmap消息问题

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -88,6 +88,8 @@ func (ch *cloudHub) Start() {
 	// start dispatch message from the cloud to edge node
 	go ch.dispatcher.DispatchDownstream()
 
+	go ch.dispatcher.CheckPools()
+
 	// check whether the certificates exist in the local directory,
 	// and then check whether certificates exist in the secret, generate if they don't exist
 	if err := httpserver.PrepareAllCerts(); err != nil {

--- a/cloud/pkg/cloudhub/common/message_pool.go
+++ b/cloud/pkg/cloudhub/common/message_pool.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -30,6 +31,7 @@ import (
 // and one that does not. For each type of message, we use the `queue` to
 // mark the order of sending, and use the `store` to store specific messages
 type NodeMessagePool struct {
+	InitTime int64
 	// AckMessageStore store message that will send to edge node
 	// and require acknowledgement from edge node.
 	AckMessageStore cache.Store
@@ -47,6 +49,7 @@ type NodeMessagePool struct {
 // InitNodeMessagePool init node message pool for node
 func InitNodeMessagePool(nodeID string) *NodeMessagePool {
 	return &NodeMessagePool{
+		InitTime:          time.Now().Unix(),
 		AckMessageStore:   cache.NewStore(AckMessageKeyFunc),
 		AckMessageQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), nodeID),
 		NoAckMessageStore: cache.NewStore(NoAckMessageKeyFunc),

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -241,7 +241,7 @@ func (md *messageDispatcher) enqueueAckMessage(nodeID string, msg *beehivemodel.
 	// If the message operation is delete, force to sync the resource message
 	// If the message operation is response, force to sync the resource message,
 	// since the edgeCore requests it.
-	if isDeleteMessage(msg) || msg.GetOperation() == beehivemodel.ResponseOperation {
+	if isDeleteMessage(msg) || msg.GetOperation() == beehivemodel.ResponseOperation || msg.GetOperation() == beehivemodel.InsertOperation {
 		shouldEnqueue = true
 		return
 	}

--- a/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
+++ b/cloud/pkg/cloudhub/dispatcher/message_dispatcher.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +87,9 @@ type MessageDispatcher interface {
 
 	// Publish sends the given message to module according to the message source
 	Publish(msg *beehivemodel.Message) error
+
+	// Check invalid session and message pools
+	CheckPools()
 }
 
 type messageDispatcher struct {
@@ -526,4 +530,32 @@ func (md *messageDispatcher) Publish(msg *beehivemodel.Message) error {
 		beehivecontext.SendToGroup(modules.EdgeControllerGroupName, *msg)
 	}
 	return nil
+}
+
+func (md *messageDispatcher) CheckPools() {
+	for {
+		now := time.Now().Unix()
+		temp := make(map[string]int)
+		md.NodeMessagePools.Range(func(key, value interface{}) bool {
+			_, exists := md.SessionManager.GetSession(key.(string))
+			if exists {
+				if value.(*common.NodeMessagePool).InitTime+3600*8 < now {
+					temp[key.(string)] = 1
+				}
+			}
+			return true
+		})
+
+		for key, _ := range temp {
+			md.NodeMessagePools.Delete(key)
+		}
+
+		time.Sleep(time.Duration(3600) * time.Second)
+
+		select {
+		case <-beehivecontext.Done():
+			return
+		default:
+		}
+	}
 }

--- a/cloud/pkg/cloudhub/handler/message_handler.go
+++ b/cloud/pkg/cloudhub/handler/message_handler.go
@@ -122,8 +122,10 @@ func (mh *messageHandler) HandleConnection(connection conn.Connection) {
 		klog.Infof("edge node %s for project %s connected", nodeInfo.NodeID, nodeInfo.ProjectID)
 
 		// init node message pool and add to the dispatcher
-		nodeMessagePool := common.InitNodeMessagePool(nodeID)
-		mh.MessageDispatcher.AddNodeMessagePool(nodeID, nodeMessagePool)
+		// nodeMessagePool := common.InitNodeMessagePool(nodeID)
+		// mh.MessageDispatcher.AddNodeMessagePool(nodeID, nodeMessagePool)
+		// check for an exist one
+		nodeMessagePool := mh.MessageDispatcher.GetNodeMessagePool(nodeID)
 
 		keepaliveInterval := time.Duration(mh.KeepaliveInterval) * time.Second
 		// create a node session for each edge node


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->
修复2个Cloudcore重启前后，正确初始化messagePool，以将来自K8s的Insert类型的消息暂存，
下发到因重启而新接入的Edge

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
