### PR TITLE
MIKU-0 [keruntime]: Make cloud core node id configurable.

### DIFF
--- a/cloud/cmd/cloudcore/app/options/options.go
+++ b/cloud/cmd/cloudcore/app/options/options.go
@@ -33,12 +33,12 @@ type CloudCoreOptions struct {
 	CloudCoreNodeFile string
 }
 
-const CloudCoreIDFIle = "/home/qboxserve/.miku-nodeid"
+const DefaultCloudCoreIDFIle = "/home/qboxserver/.miku-nodeid"
 
 func NewCloudCoreOptions() *CloudCoreOptions {
 	return &CloudCoreOptions{
 		ConfigFile:        path.Join(constants.DefaultConfigDir, "cloudcore.yaml"),
-		CloudCoreNodeFile: CloudCoreIDFIle,
+		CloudCoreNodeFile: DefaultCloudCoreIDFIle,
 	}
 }
 

--- a/cloud/pkg/sessionmanager/identity/identity.go
+++ b/cloud/pkg/sessionmanager/identity/identity.go
@@ -16,13 +16,11 @@ type IDType uint
 
 const (
 	// UUID will automatically generate a id for cloud.
-	UUID IDType = iota
+	UUID IDType = 0
 	// Hash will generate a hash id over cloud mac address and addr.
-	Hash IDType = iota
+	Hash IDType = 1
 	// Configured will use the id user config.
-	Configured IDType = iota
-	// System will read cloud id from file, this cloud id will read while start.
-	System IDType = iota
+	Configured IDType = 2
 )
 
 // CloudInfo is some cloud info to generate hash.
@@ -47,12 +45,12 @@ type CloudIdentity struct {
 // NewCloudIdentity need modules config, return CloudIdentity, will generate id while new CloudIdentity.
 func NewCloudIdentity(modules *v1alpha1.Modules) *CloudIdentity {
 	conf := &CloudIdentity{
-		idType: IDType(modules.CloudIDManager.IDType),
+		idType: IDType(modules.CloudIdentity.IDType),
 	}
 
 	switch conf.idType {
 	case Configured:
-		if err := conf.validateID(modules.CloudIDManager.ID); err != nil {
+		if err := conf.validateID(modules.CloudIdentity.ID); err != nil {
 			return nil
 		}
 	case Hash:
@@ -69,7 +67,7 @@ func NewCloudIdentity(modules *v1alpha1.Modules) *CloudIdentity {
 			return nil
 		}
 	default:
-		conf.id = modules.CloudIDManager.ID
+		conf.id = modules.CloudIdentity.ID
 	}
 
 	if conf.id == "" {

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/default.go
@@ -146,9 +146,8 @@ func NewDefaultCloudCoreConfig() *CloudCoreConfig {
 				Enable: true,
 				Mode:   InternalMode,
 			},
-			CloudIDManager: &CloudIDManager{
-				Enable: true,
-				IDType: 3,
+			CloudIdentity: &CloudIdentity{
+				IDType: 2,
 				ID:     "cloudcore",
 			},
 		},

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
@@ -49,16 +49,27 @@ func (c *CloudCoreConfig) Parse(filename string) error {
 
 func (c *CloudCoreConfig) ReadNodeID(filename string) error {
 	nodeIDFile := ""
+	// Read node id from default file
 	if validation.FileIsExist(filename) {
 		nodeIDFile = filename
 	}
+	// Read node id from config file
 	if c.CloudCoreNodeIDFile != "" && validation.FileIsExist(c.CloudCoreNodeIDFile) {
 		nodeIDFile = c.CloudCoreNodeIDFile
 	}
+	// Check node id exist
 	if nodeIDFile == "" && !validation.FileIsExist(nodeIDFile) {
-		err := errors.New("failed to read configfile")
-		klog.Errorf("Failed to read both configfile %s and %s: %v", filename, c.CloudCoreNodeIDFile, err)
-		return err
+		// Check default node id exist
+		if c.CloudCoreNodeID == "" {
+			err := errors.New("failed to read configfile")
+			klog.Errorf("Failed to read both configfile %s and %s: %v", filename, c.CloudCoreNodeIDFile, err)
+			return err
+		} else {
+			if c.Modules.CloudIdentity.IDType == 3 {
+				c.Modules.CloudIdentity.ID = c.CloudCoreNodeID
+			}
+			return nil
+		}
 	}
 	data, err := os.ReadFile(nodeIDFile)
 	if err != nil {
@@ -66,8 +77,8 @@ func (c *CloudCoreConfig) ReadNodeID(filename string) error {
 		return err
 	}
 	c.CloudCoreNodeID = string(data)
-	if c.Modules.CloudIDManager.IDType == 3 {
-		c.Modules.CloudIDManager.ID = string(data)
+	if c.Modules.CloudIdentity.IDType == 3 {
+		c.Modules.CloudIdentity.ID = string(data)
 	}
 	return nil
 }

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 
+	"github.com/kubeedge/kubeedge/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 )
@@ -47,9 +48,21 @@ func (c *CloudCoreConfig) Parse(filename string) error {
 }
 
 func (c *CloudCoreConfig) ReadNodeID(filename string) error {
-	data, err := os.ReadFile(filename)
+	nodeIDFile := ""
+	if validation.FileIsExist(filename) {
+		nodeIDFile = filename
+	}
+	if c.CloudCoreNodeIDFile != "" && validation.FileIsExist(c.CloudCoreNodeIDFile) {
+		nodeIDFile = c.CloudCoreNodeIDFile
+	}
+	if nodeIDFile == "" && !validation.FileIsExist(nodeIDFile) {
+		err := errors.New("failed to read configfile")
+		klog.Errorf("Failed to read both configfile %s and %s: %v", filename, c.CloudCoreNodeIDFile, err)
+		return err
+	}
+	data, err := os.ReadFile(nodeIDFile)
 	if err != nil {
-		klog.Errorf("Failed to read configfile %s: %v", filename, err)
+		klog.Errorf("Failed to read configfile %s: %v", nodeIDFile, err)
 		return err
 	}
 	c.CloudCoreNodeID = string(data)

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
@@ -65,7 +65,7 @@ func (c *CloudCoreConfig) ReadNodeID(filename string) error {
 			klog.Errorf("Failed to read both configfile %s and %s: %v", filename, c.CloudCoreNodeIDFile, err)
 			return err
 		} else {
-			if c.Modules.CloudIdentity.IDType == 3 {
+			if c.Modules.CloudIdentity.IDType == 2 {
 				c.Modules.CloudIdentity.ID = c.CloudCoreNodeID
 			}
 			return nil
@@ -77,7 +77,7 @@ func (c *CloudCoreConfig) ReadNodeID(filename string) error {
 		return err
 	}
 	c.CloudCoreNodeID = string(data)
-	if c.Modules.CloudIdentity.IDType == 3 {
+	if c.Modules.CloudIdentity.IDType == 2 {
 		c.Modules.CloudIdentity.ID = string(data)
 	}
 	return nil

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -119,8 +119,8 @@ type Modules struct {
 	Router *Router `json:"router,omitempty"`
 	// IptablesManager indicates iptables module config
 	IptablesManager *IptablesManager `json:"iptablesManager,omitempty"`
-	// CloudIDManager store the cloud core ident
-	CloudIDManager *CloudIDManager `json:"cloudIDManager,omitempty"`
+	// CloudIdentity store the cloud core ident
+	CloudIdentity *CloudIdentity `json:"cloudIdentity,omitempty"`
 }
 
 // CloudHub indicates the config of CloudHub module.
@@ -510,10 +510,8 @@ type IptablesManager struct {
 	Mode IptablesMgrMode `json:"mode,omitempty"`
 }
 
-// CloudIDManager ident the cloud core
-type CloudIDManager struct {
-	// default true
-	Enable bool `json:"enable"`
+// CloudIdentity ident the cloud core
+type CloudIdentity struct {
 	// ID Type
 	// default uuid
 	// 0: uuid, 1: hash, 2: configured

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/types.go
@@ -36,6 +36,8 @@ type CloudCoreConfig struct {
 	Modules *Modules `json:"modules,omitempty"`
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental features.
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+	// CloudCoreNodeIDFile indicates the file where the cloud node id is stored.
+	CloudCoreNodeIDFile string `json:"cloudCoreNodeIDFile,omitempty"`
 	// CloudCoreNodeID identity the cloud itself.
 	CloudCoreNodeID string `json:"cloudCoreNodeID,omitempty"`
 }


### PR DESCRIPTION
feat: make cloud core node id configurable.
fix: fix the default cloud core id file path.
feat: add cloud core node id file exist check.
fix: delete the system type, use configured instead.

现在对nodeID的读取顺序优先级是
config file( `config.CloudCOreNodeIDFile` )
default file( `/home/qboxserver/.miku-nodeid` )
configed node id( `config.CloudCoreNodeID` )，如果前两个读取到了，会覆盖此处配置，如果没读取到且这个配置项也为空的情况下，则会报错无法启动。如果这个非空且从文件读取不到则使用这个ID为`CloudCoreNodeID`。
当`config.Modules.CloudIdentity.IDType`的值为2(`configured`)的时候，将会使用设置的cloudID。
