### PR TITLE
MIKU-0 [keruntime]: fix the bug of token will update even it is exist while restart.

### DIFF
--- a/cloud/pkg/cloudhub/cloudhub.go
+++ b/cloud/pkg/cloudhub/cloudhub.go
@@ -62,7 +62,7 @@ func newCloudHub(modules *v1alpha1.Modules) *cloudHub {
 }
 
 func Register(modules *v1alpha1.Modules) {
-	hubconfig.InitConfigure(modules.CloudHub)
+	hubconfig.InitConfigure(modules.CloudHub, modules.CloudIdentity.ID)
 	core.Register(newCloudHub(modules))
 }
 

--- a/cloud/pkg/cloudhub/config/config.go
+++ b/cloud/pkg/cloudhub/config/config.go
@@ -20,9 +20,10 @@ type Configure struct {
 	CaKey         []byte
 	Cert          []byte
 	Key           []byte
+	CloudID       string
 }
 
-func InitConfigure(hub *v1alpha1.CloudHub) {
+func InitConfigure(hub *v1alpha1.CloudHub, cloudID string) {
 	once.Do(func() {
 		if len(hub.AdvertiseAddress) == 0 {
 			klog.Exit("AdvertiseAddress must be specified!")
@@ -30,6 +31,7 @@ func InitConfigure(hub *v1alpha1.CloudHub) {
 
 		Config = Configure{
 			CloudHub: *hub,
+			CloudID:  cloudID,
 		}
 
 		ca, err := os.ReadFile(hub.TLSCAFile)

--- a/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
+++ b/cloud/pkg/cloudhub/servers/httpserver/signcerts.go
@@ -83,7 +83,7 @@ func GenerateToken() error {
 	// combine caHash and tokenString into caHashAndToken
 	caHashToken := strings.Join([]string{caHash, tokenString}, ".")
 	// save caHashAndToken to secret
-	err = CreateTokenSecret([]byte(caHashToken))
+	err = CreateTokenSecret([]byte(caHashToken), hubconfig.Config.CloudID)
 	if err != nil {
 		return fmt.Errorf("failed to create tokenSecret, err: %v", err)
 	}
@@ -93,7 +93,7 @@ func GenerateToken() error {
 		for {
 			<-t.C
 			refreshedCaHashToken := refreshToken()
-			if err := CreateTokenSecret([]byte(refreshedCaHashToken)); err != nil {
+			if err := CreateTokenSecret([]byte(refreshedCaHashToken), hubconfig.Config.CloudID); err != nil {
 				klog.Exitf("Failed to create the ca token for edgecore register, err: %v", err)
 			}
 		}

--- a/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
+++ b/pkg/apis/componentconfig/cloudcore/v1alpha1/helper.go
@@ -66,6 +66,7 @@ func (c *CloudCoreConfig) ReadNodeID(filename string) error {
 			return err
 		} else {
 			if c.Modules.CloudIdentity.IDType == 2 {
+				klog.Infof("Using CloudCoreNodeID from config file as node id: %s", c.CloudCoreNodeID)
 				c.Modules.CloudIdentity.ID = c.CloudCoreNodeID
 			}
 			return nil
@@ -78,6 +79,7 @@ func (c *CloudCoreConfig) ReadNodeID(filename string) error {
 	}
 	c.CloudCoreNodeID = string(data)
 	if c.Modules.CloudIdentity.IDType == 2 {
+		klog.Infof("Using nodeIDFile data as node id, file: %s, nodeID: %s", nodeIDFile, c.CloudCoreNodeID)
 		c.Modules.CloudIdentity.ID = string(data)
 	}
 	return nil


### PR DESCRIPTION
fix: fix the bug of token will regenerate even it is exist while cloudcore restart.
feat: add labels [updatedTime, updatedBy(cloudcore node id)] into secret token Labels.
feat: add a log output shows where the current cloud node id from and what it is.
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/db812ecf-6a25-4363-8e21-ca2c5c29674f">

如下图，但只能存时间戳，因为labels不支持类似rfc3339之类的带空格` `或者`:`的格式

<img width="1397" alt="image" src="https://github.com/user-attachments/assets/2a408f14-ec51-4683-b548-46ae5776cd42">
